### PR TITLE
modified UserTracker::exit() to avoid crush on exit

### DIFF
--- a/src/ofxNiTE2.cpp
+++ b/src/ofxNiTE2.cpp
@@ -60,6 +60,7 @@ bool UserTracker::setup(ofxNI2::Device &device)
 
 void UserTracker::exit()
 {
+    userTrackerFrame.release();
 	ofRemoveListener(device->updateDevice, this, &UserTracker::onUpdate);
 	
 	map<nite::UserId, User::Ref>::iterator it = users.begin();


### PR DESCRIPTION
アプリ終了時にuserTrackerFrameのデストラクタが呼ばれたタイミングでsegmentation faultが出てしまうので、
exit()内で明示的にreleaseを呼ぶようにしました。
