### PR TITLE
[Grayscale::getShaderCode] fixed near/far clipping

### DIFF
--- a/src/ofxNI2.cpp
+++ b/src/ofxNI2.cpp
@@ -526,17 +526,7 @@ string Grayscale::getShaderCode() const
 		{
 			float c = texture2DRect(tex, gl_TexCoord[0].xy).r;
 			
-			c -= near_value;
-			if (c > 0.)
-			{
-				c /= far_value;
-				if (c > 1.)
-					c = 1.;
-			}
-			else
-			{
-				c = 0.;
-			}
+			c = (near_value >= far_value) ? 0. : clamp((c-near_value)/(far_value-near_value), 0., 1.);
 			
 			gl_FragColor = gl_Color * vec4(c, c, c, 1.);
 		}


### PR DESCRIPTION
use far_value as distance from camera. (not from near_value)

farの値がnearからの距離として計算されていました。
意図的な動作でしたら無視してください。
