### PR TITLE
added glInternalFormat arg in tex.allocate

### DIFF
--- a/src/ofxNI2.cpp
+++ b/src/ofxNI2.cpp
@@ -463,7 +463,7 @@ void DepthStream::updateTextureIfNeeded()
 		
 		tex.allocate(data);
 #elif OF_VERSION_MINOR > 7
-		tex.allocate(getWidth(), getHeight(), true, GL_LUMINANCE, GL_UNSIGNED_SHORT);
+		tex.allocate(getWidth(), getHeight(), GL_RGBA, true, GL_LUMINANCE, GL_UNSIGNED_SHORT);
 #endif
 	}
 


### PR DESCRIPTION
oFの v0.8.0で見たところ、tex.allocateにはbUseARBExtentionの前にglInternalFormatの指定が必要なようでした。
