### PR TITLE
Update for 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
-OSX:
+Setup
+========
+
+OSX
+--------
 
 Add to Run Script
 
 	cp -R ../../../addons/ofxNI2/libs/OpenNI2/lib/osx/ "$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/";
 	cp -R ../../../addons/ofxNI2/libs/NiTE2/lib/osx/ "$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/";
+
+Uncomment
+
+    //#define HAVE_NITE2
+
+in `ofxNI2.h` to use NiTE2.
+
+Visual Studio
+--------
+
+Download OpenNI2 from http://structure.io/openni and install. Choose x86 (32bit) or x64 (64bit) depending on your project settings.
+
+Copy `OpenNI2\`, `OpenNI2.ini` and `OpenNI2.dll` from `C:\Program Files (x86)\OpenNI2\Redist` (x86) or `C:\Program Files\OpenNI2\Redist` (x64) to `projectFolder\bin\`.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ Visual Studio
 Download OpenNI2 from http://structure.io/openni and install. Choose x86 (32bit) or x64 (64bit) depending on your project settings.
 
 Copy `OpenNI2\`, `OpenNI2.ini` and `OpenNI2.dll` from `C:\Program Files (x86)\OpenNI2\Redist` (x86) or `C:\Program Files\OpenNI2\Redist` (x64) to `projectFolder\bin\`.
+
+To use Microsoft Kinect through OpenNI2, install Microsoft SDK 1.x as well.

--- a/src/ofxNI2.cpp
+++ b/src/ofxNI2.cpp
@@ -475,7 +475,7 @@ void DepthStream::updateTextureIfNeeded()
 		
 		tex.allocate(data);
 #elif OF_VERSION_MINOR > 7
-		tex.allocate(getWidth(), getHeight(), GL_RGBA, true, GL_LUMINANCE, GL_UNSIGNED_SHORT);
+        tex.allocate(pix.getFrontBuffer());
 #endif
 	}
 

--- a/src/ofxNI2.cpp
+++ b/src/ofxNI2.cpp
@@ -8,7 +8,7 @@ namespace ofxNI2
 	{
 		if (rc == openni::STATUS_OK) return true;
 		ofLogError("ofxNI2") << openni::OpenNI::getExtendedError();
-		return false;
+		throw;
 	}
 
 	bool check_error(openni::Status rc)
@@ -112,7 +112,7 @@ bool Device::setup(string oni_file_path)
 	oni_file_path = ofToDataPath(oni_file_path);
 	
 	assert_error(device.open(oni_file_path.c_str()));
-	assert_error(device.setDepthColorSyncEnabled(true));
+	check_error(device.setDepthColorSyncEnabled(true));
 	
 	return true;
 }

--- a/src/ofxNI2.cpp
+++ b/src/ofxNI2.cpp
@@ -27,17 +27,17 @@ namespace ofxNI2
 		// initialize oF path, don't comment out
 		ofToDataPath(".");
 		
-		if (ofFile::doesFileExist("Drivers", false))
-		{
-			string path = "Drivers";
-			setenv("OPENNI2_DRIVERS_PATH", path.c_str(), 1);
+		//if (ofFile::doesFileExist("Drivers", false))
+		//{
+		//	string path = "Drivers";
+		//	setenv("OPENNI2_DRIVERS_PATH", path.c_str(), 1);
 			assert_error(openni::OpenNI::initialize());
-		}
-		else
-		{
-			ofLogError("ofxNI2") << "libs not found";
-			ofExit(-1);
-		}
+		//}
+		//else
+		//{
+		//	ofLogError("ofxNI2") << "libs not found";
+		//	ofExit(-1);
+		//}
 	}
 }
 
@@ -479,10 +479,10 @@ void DepthStream::updateTextureIfNeeded()
 	Stream::updateTextureIfNeeded();
 }
 
-ofPixels DepthStream::getPixelsRef(int near, int far, bool invert)
+ofPixels DepthStream::getPixelsRef(int _near, int _far, bool invert)
 {
 	ofPixels pix;
-	depthRemapToRange(getPixelsRef(), pix, near, far, invert);
+	depthRemapToRange(getPixelsRef(), pix, _near, _far, invert);
 	return pix;
 }
 

--- a/src/ofxNI2.h
+++ b/src/ofxNI2.h
@@ -243,10 +243,10 @@ public:
 	
 	void begin();
 	
-	inline void setNear(float near) { near_value = near; }
+	inline void setNear(float _near) { near_value = _near; }
 	inline float getNear() const { return near_value; }
 	
-	inline void setFar(float far) { far_value = far; }
+	inline void setFar(float _far) { far_value = _far; }
 	inline float getFar() const { return far_value; }
 	
 protected:

--- a/src/ofxNI2.h
+++ b/src/ofxNI2.h
@@ -5,6 +5,8 @@
 #include "OpenNI.h"
 #include <assert.h>
 
+//#define HAVE_NITE2
+
 #include "utils/DoubleBuffer.h"
 
 namespace ofxNI2

--- a/src/ofxNiTE2.cpp
+++ b/src/ofxNiTE2.cpp
@@ -2,6 +2,8 @@
 
 #include "utils/DepthRemapToRange.h"
 
+#ifdef HAVE_NITE2
+
 namespace ofxNiTE2
 {
 	void init()
@@ -127,10 +129,10 @@ void UserTracker::onNewFrame(nite::UserTracker &tracker)
 	}
 }
 
-ofPixels UserTracker::getPixelsRef(int near, int far, bool invert)
+ofPixels UserTracker::getPixelsRef(int _near, int _far, bool invert)
 {
 	ofPixels pix;
-	ofxNI2::depthRemapToRange(getPixelsRef(), pix, near, far, invert);
+	ofxNI2::depthRemapToRange(getPixelsRef(), pix, _near, _far, invert);
 	return pix;
 }
 
@@ -347,3 +349,5 @@ void Joint::updateJointData(const nite::SkeletonJoint& data)
 	setGlobalOrientation(ofQuaternion(-rot.x, -rot.y, rot.z, rot.w));
 	setGlobalPosition(pos.x, pos.y, -pos.z);
 }
+
+#endif

--- a/src/ofxNiTE2.h
+++ b/src/ofxNiTE2.h
@@ -5,6 +5,8 @@
 
 #include "NiTE.h"
 
+#ifdef HAVE_NITE2
+
 namespace ofxNiTE2
 {
 	class UserTracker;
@@ -135,3 +137,5 @@ protected:
 	void onNewFrame(nite::UserTracker &tracker);
 	void onUpdate(ofEventArgs&);
 };
+
+#endif

--- a/src/utils/DepthRemapToRange.h
+++ b/src/utils/DepthRemapToRange.h
@@ -4,7 +4,7 @@
 
 namespace ofxNI2
 {
-	inline void depthRemapToRange(const ofShortPixels &src, ofPixels &dst, int near, int far, int invert)
+	inline void depthRemapToRange(const ofShortPixels &src, ofPixels &dst, int _near, int _far, int invert)
 	{
 		int N = src.getWidth() * src.getHeight();
 		dst.allocate(src.getWidth(), src.getHeight(), 1);
@@ -12,15 +12,15 @@ namespace ofxNI2
 		const unsigned short *src_ptr = src.getPixels();
 		unsigned char *dst_ptr = dst.getPixels();
 		
-		float inv_range = 1. / (far - near);
+		float inv_range = 1. / (_far - _near);
 		
 		if (invert)
-			std::swap(near, far);
+			std::swap(_near, _far);
 		
 		for (int i = 0; i < N; i++)
 		{
 			unsigned short C = *src_ptr;
-			*dst_ptr = ofMap(C, near, far, 0, 255, true);
+			*dst_ptr = ofMap(C, _near, _far, 0, 255, true);
 			src_ptr++;
 			dst_ptr++;
 		}


### PR DESCRIPTION
Several things:

* fix issue https://github.com/satoruhiga/ofxNI2/issues/11
* add flag to enable/disable NiTE (technically it's not available anymore)
* Visual Studio support (openni has to be installed separately)
* Fix path issue in OSX (`ofToDataPath(".")` thing is not working on 0.9.0; instead `ofFilePath::getCurrentExeDir()` is used)
* update readme
